### PR TITLE
Add resource link to strategize

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,12 @@ As a starting point, we recommend [Core Domain Charts](https://github.com/ddd-cr
 
 ![Core Domain Charts](resources/core-domain-chart.jpg)
 
-#### Tools
+#### Tools/Resources
 
 - [Core Domain Charts](https://github.com/ddd-crew/core-domain-charts)
 - [Purpose Alignment Model](https://www.informit.com/articles/article.aspx?p=1384195&seqNum=2)
 - [Wardley Mapping](https://learnwardleymapping.com/)
+- [Revisiting the Basics of Domain-Driven Design](https://vladikk.com/2018/01/26/revisiting-the-basics-of-ddd/)
 
 #### Who to Involve
 


### PR DESCRIPTION
add "Revisiting the Basics of Domain-Driven Design" as a resource for strategize 