### PR TITLE
Renaming PST model to current terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ As a starting point, we recommend visualising sociotechnical architecture with t
 #### Tools
 
 - [Dynamic Reteaming](https://leanpub.com/dynamicreteaming) 
-- [Pioneers, Settlers & Town Planners](http://wardleypedia.org/mediawiki/index.php/Pioneers_settlers_town_planners)
+- [Explorers, Villagers & Town Planners](https://medium.com/mappingpractice/how-to-organise-yourself-f36f084a611b)
 - [Team Topologies](https://teamtopologies.com/)
 - [Visualising Sociotechnical Architecture with Context Maps](https://speakerdeck.com/mploed/visualizing-sociotechnical-architectures-with-context-maps)
 


### PR DESCRIPTION
Simon Wardley said "I used to call this system — pioneers, settlers and town planners — unfortunately the colonialist overtone of those terms made it problematic for many and with good reason." 

See https://medium.com/mappingpractice/how-to-organise-yourself-f36f084a611b